### PR TITLE
Game modify checkAllGems

### DIFF
--- a/final_project/monster_game_CUI.c
+++ b/final_project/monster_game_CUI.c
@@ -566,8 +566,6 @@ int computeRecoveryAmount(Party *pParty, Banishinfo *bi, int comboNum)
         {
             comboPlus *= 1.5;
         }
-        printf("allBanishNum: %d, comboNum: %d, comboPlus: %f\n\n",
-               bi->banishableNum, comboNum, comboPlus);
     }
 
     int recover = randomizedDamage(RECOVER_NUM * comboPlus, BLUR_DAMAGE);

--- a/final_project/monster_game_CUI.c
+++ b/final_project/monster_game_CUI.c
@@ -344,44 +344,19 @@ bool validateCommand(char *pInput)
 void checkAllGems(BattleField *pField)
 {
     Banishinfo banishable = identifyRemovableGems(pField->gems);
-    int comboNum = 1;
+    int comboNum = 0;
 
-    if (banishable.banishableNum != 0)
+    while (banishable.banishableNum != 0)
     {
+        comboNum++;
         removeGems(pField, &banishable, comboNum);
         compactGems(pField->gems);
-
-        while (true)
+        banishable = identifyRemovableGems(pField->gems);
+        if (banishable.banishableNum == 0)
         {
-            Banishinfo combo = identifyRemovableGems(pField->gems);
-            if (combo.banishableNum != 0)
-            {
-                comboNum++;
-
-                removeGems(pField, &combo, comboNum);
-                compactGems(pField->gems);
-            }
-            else if (combo.banishableNum == 0)
-                break;
+            generateNewGems(pField->gems);
+            banishable = identifyRemovableGems(pField->gems);
         }
-
-        generateNewGems(pField->gems);
-
-        while (true)
-        {
-            Banishinfo combo = identifyRemovableGems(pField->gems);
-            if (combo.banishableNum != 0)
-            {
-                comboNum++;
-
-                removeGems(pField, &combo, comboNum);
-                compactGems(pField->gems);
-            }
-            else if (combo.banishableNum == 0)
-                break;
-        }
-
-        generateNewGems(pField->gems);
     }
 }
 


### PR DESCRIPTION
## 概要
実装済みの関数のリファクタリングをする。

## 変更点
- identifyRemovableGems関数でGem配列から削除可能なGem情報をbanishinfo構造体に代入する。
- Gem移動操作後、Gem削除後、Gem再生生後のタイミングでidentifyRemovableGems関数でGem配列を毎回評価する。これまでは毎回新しい構造体を作って初期化していた(構造体は初期化後に代入してはいけないと思い込んでいた。)。なので、一度評価用banishinfo構造体変数を再利用するようにした。
- Gem再生生後の評価&削除が不十分だったことに気づいたため、whileループでGem再生後も可能な限り再生&削除するようにした

## 関連Issue
None

## 動作確認
- dokoc のデバック環境で試し問題なく動作することを確認
- dokocでエラーや警告が出ないことを確認

## その他
- gccオプションで警告が全く出なくなるまでのチェックは後日実施する
